### PR TITLE
removed python-apt since it is no longer supported

### DIFF
--- a/extraMetaPy.py
+++ b/extraMetaPy.py
@@ -5,7 +5,6 @@
 # REQUIRES EXIFTOOL INSTALLED (apt install libimage-exiftool-perl)
 
 import sys
-import apt
 import os
 import socks
 import socket
@@ -14,6 +13,7 @@ import time
 import subprocess
 import simplejson
 import urllib.request
+import shutil
 from googlesearch import search
 from colorama import Fore, Style
 from urllib.parse import urlparse
@@ -69,7 +69,6 @@ nodownload = args.nodownload
 socks_ip = args.socks
 socks_port = args.socks_port
 
-
 # Connect to socks5 proxy if true.
 if socks_ip:
     socks.set_default_proxy(socks.SOCKS5, socks_ip, socks_port)
@@ -77,25 +76,10 @@ if socks_ip:
 
 
 # Check if 'libimage-exiftool-perl' is installed on the system.
-cache = apt.Cache()
-pkg = cache['libimage-exiftool-perl']
-if not pkg.is_installed:
-    if not nodownload:
-        print(f'{RED}{BRIGHT}[X] {WHITE}exiftool{NORM} is not installed')
-        exifInstall = input(f'Install {BRIGHT}exiftool{NORM}? (y/n){RST} ')
-        if exifInstall == 'y':
-            pkg.mark_install()
-            try:
-                cache.commit()
-                print(f'{GREEN}{BRIGHT}[+] {WHITE}exiftool{NORM} installed, continuing')
-                time.sleep(2)
-            except:
-                print(f'{RED}{BRIGHT}[X] {RST}{DIM}Failed to install {RST}{BRIGHT}exiftool{DIM}, try manually{RST}')
-                exit(1)
-        else:
-            print(f'{BRIGHT}Google Dork mode{DIM} requires{RST} {BRIGHT}exiftool{DIM} installed')
-            exit(1)
-
+pkg = shutil.which("libimage-exiftool-perl")
+if pkg is None:
+    print(f'{RED}{BRIGHT}[X] {WHITE}exiftool{NORM} is not installed')
+    sys.exit()
 
 # Create logfile 'empy.log'.
 timestamp = datetime.now().strftime("%H:%M:%S")

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,17 @@ NC='\033[0m' # No Color
 
 # Give execution permission to extraMetaPy.py and copy to /usr/bin
 echo -e ${RED}[*] ${WHITE}Installing extraMetaPy 2.0...${NC}
-pip3 install PySocks colorama googlesearch_python python_apt simplejson
+pip install PySocks colorama googlesearch_python simplejson
+
+# need the libimage-exiftool-perl
+REQUIRED_PKG="libimage-exiftool-perl"
+PKG_OK=$(dpkg-query -W --showformat='${Status}\n' $REQUIRED_PKG|grep "install ok installed")
+echo Checking for $REQUIRED_PKG: $PKG_OK
+if [ "" = "$PKG_OK" ]; then
+  echo "No $REQUIRED_PKG. Setting up $REQUIRED_PKG."
+  sudo apt-get --yes install $REQUIRED_PKG
+fi
+
 chmod +x extraMetaPy.py
 cp extraMetaPy.py /usr/bin/extraMetaPy
 echo -e ${NC}
@@ -18,4 +28,4 @@ echo -e ${GREEN}[+] ${WHITE}Done!${NC}
 echo -e
 
 # Execute and display it
-extraMetaPy -h
+./extraMetaPy.py -h

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 PySocks == 1.7.1
 colorama == 0.4.4
 googlesearch_python == 1.0.1
-python_apt == 2.3.0+b1
 simplejson == 3.17.5


### PR DESCRIPTION
This changed was spawned from a discussion of the pyenv in #ptk-v2-team. It basically wasn't working anymore due to the issue of python-apt being deprecated. I switched it up to to use python shutil's to check for installation and made the install.sh script the primary function for actually installing the exiftool package. Feel free to ignore or deny this if you prefer your version. I can always access later with my fork. 